### PR TITLE
WIP: Add option to show guids on list command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,7 @@ Below are some examples on how to use it:
     $ osf init
 
     # list all files for the project
+    # (add --long to get file guids and download urls, too)
     $ osf ls
 
     # fetch all files for the project

--- a/docs/cli-usage.rst
+++ b/docs/cli-usage.rst
@@ -18,6 +18,9 @@ Below are some examples on how to use the command-line program:
     # list all files for a public project
     $ osf -p <projectid> list
 
+    # list all files for a public project, including guids & download urls
+    $ osf -p <projectid> list --long
+
     # setup a local folder for an existing project
     $ osf init
 

--- a/osfclient/__main__.py
+++ b/osfclient/__main__.py
@@ -85,6 +85,9 @@ def main():
     # List all files in a project
     list_parser = _add_subparser('list', list.__doc__, aliases=['ls'])
     list_parser.set_defaults(func=list_)
+    list_parser.add_argument('-l', '--long',
+                             help='List in long format',
+                             action='store_true')
 
     # Upload a single file or a directory tree
     upload_parser = _add_subparser('upload', upload.__doc__)

--- a/osfclient/cli.py
+++ b/osfclient/cli.py
@@ -8,6 +8,7 @@ from functools import wraps
 import getpass
 import os
 import sys
+import csv
 
 from six import ensure_text
 from six.moves import configparser
@@ -261,6 +262,7 @@ def list_(args):
 
     project = osf.project(args.project)
 
+    writer = csv.writer(sys.stdout)
     for store in project.storages:
         prefix = store.name
         for file_ in store.files:
@@ -268,7 +270,11 @@ def list_(args):
             if path.startswith('/'):
                 path = path[1:]
 
-            print(os.path.join(prefix, path))
+            vals = [os.path.join(prefix, path)]
+            if args.long:
+                vals.append(str(file_.guid))
+                vals.append(str(file_.download))
+            writer.writerow(vals)
 
 
 @might_need_auth

--- a/osfclient/models/file.py
+++ b/osfclient/models/file.py
@@ -31,6 +31,8 @@ class File(OSFCore):
         self._html_url = self._get_attribute(file, 'links', 'html')
         self._delete_url = self._get_attribute(file, 'links', 'delete')
         self.osf_path = self._get_attribute(file, 'attributes', 'path')
+        self.guid = self._get_attribute(file, 'attributes', 'guid')
+        self.download = self._get_attribute(file, 'links', 'download')
         self.path = self._get_attribute(file,
                                         'attributes', 'materialized_path')
         self.name = self._get_attribute(file, 'attributes', 'name')

--- a/osfclient/tests/mocks.py
+++ b/osfclient/tests/mocks.py
@@ -4,12 +4,23 @@ from mock import MagicMock, PropertyMock
 # When using a PropertyMock store it as an attribute
 # of the mock it belongs to so that later on a caller
 # can assert whether or not it has been accessed
-def MockFile(name):
+def MockFile(name, guid=None, download_url=None):
     mock = MagicMock(name='File-%s' % name, path=name)
     path = PropertyMock(return_value=name)
     type(mock).path = path
     mock._path_mock = path
     mock._html_url = 'https://example.com'
+
+    # mock guid
+    guid = PropertyMock(return_value=guid)
+    type(mock).guid = guid
+    mock._guid_mock = guid
+
+    # mock download url
+    download = PropertyMock(return_value=download_url)
+    type(mock).download = download
+    mock._download_mock = download
+
     hashes_dict = dict(md5='0' * 32, sha256='0' * 64)
     hashes = PropertyMock(return_value=hashes_dict)
     type(mock).hashes = hashes
@@ -30,7 +41,9 @@ def MockFolder(name):
 
 def MockStorage(name):
     mock = MagicMock(name='Storage-%s' % name,
-                     files=[MockFile('/a/a/a'), MockFile('b/b/b')])
+                     files=[MockFile('/a/a/a', guid=None, download_url='www.mock/guid-download.com'),
+                            MockFile('b/b/b', guid=None, download_url=''),
+                            MockFile('c/c/c', guid='a1b2c', download_url='')])
     name = PropertyMock(return_value=name)
     type(mock).name = name
     mock._name_mock = name
@@ -50,10 +63,11 @@ def MockProject(name):
 
 def MockArgs(username=None, password=None, output=None, project=None,
              source=None, destination=None, local=None, remote=None,
-             target=None, force=False, update=False, recursive=False):
+             target=None, force=False, update=False, recursive=False,
+             long=False):
     args = MagicMock(spec=['username', 'password', 'output', 'project',
                            'source', 'destination', 'target', 'force',
-                           'recursive'])
+                           'recursive', 'long'])
     args._username_mock = PropertyMock(return_value=username)
     type(args).username = args._username_mock
     args._password_mock = PropertyMock(return_value=password)
@@ -84,6 +98,9 @@ def MockArgs(username=None, password=None, output=None, project=None,
 
     args._recursive_mock = PropertyMock(return_value=recursive)
     type(args).recursive = args._recursive_mock
+
+    args._long_mock = PropertyMock(return_value=long)
+    type(args).long = args._long_mock
 
     return args
 


### PR DESCRIPTION
Proposed: `-l` or `--long`, analogous to unix `ls`, for #118 

This is to show the `guid`, which is the 5 letter code after osf.io. Download URLs can be formed from `osf.io/{guid}/download`. This is useful to make a mapping between logical file names and download URLs

TBD:

 * what other properties to show?
 * allow other separator than `,`? Escape `,`s in filenames (because people)

BUGS:

sometimes the OSF API will return `None` for guids for files, even if they are there in the web interface. Need to check API docs more then contact support if required.

Note:

original proposal was to extend the upload command, but this doesn't seem to return guids and putting this on `list` seems more generally useful.