### PR TITLE
Add clone support for registrations

### DIFF
--- a/osfclient/api.py
+++ b/osfclient/api.py
@@ -1,3 +1,4 @@
+from .exceptions import OSFException
 from .models import OSFCore
 from .models import Project
 
@@ -20,8 +21,15 @@ class OSF(OSFCore):
 
     def project(self, project_id):
         """Fetch project `project_id`."""
-        url = self._build_url('nodes', project_id)
-        return Project(self._json(self._get(url), 200), self.session)
+        type_ = self.guid(project_id)
+        url = self._build_url(type_, project_id)
+        if type_ in Project._types:
+            return Project(self._json(self._get(url), 200), self.session)
+        raise OSFException('{} is unrecognized type {}. Clone supports projects and registrations'.format(project_id, type_))
+
+    def guid(self, guid):
+        """Determines JSONAPI type for provided GUID"""
+        return self._json(self._get(self._build_url('guids', guid)), 200)['data']['type']
 
     @property
     def username(self):

--- a/osfclient/models/project.py
+++ b/osfclient/models/project.py
@@ -3,6 +3,11 @@ from .storage import Storage
 
 
 class Project(OSFCore):
+    _types = [
+        'nodes',
+        'registrations'
+    ]
+
     def _update_attributes(self, project):
         if not project:
             return

--- a/osfclient/tests/fake_responses.py
+++ b/osfclient/tests/fake_responses.py
@@ -2,7 +2,7 @@ import json
 
 
 # Use this to initialize a `Project` instance
-project_node = json.loads("""
+node_json = """
 {
   "data": {
     "relationships": {
@@ -186,11 +186,20 @@ project_node = json.loads("""
         "qatest"
       ]
     },
-    "type": "nodes",
+    "type": "{type}",
     "id": "f3szh"
   }
 }
-""")
+"""
+
+def _build_node(type_):
+    node = json.loads(node_json)
+    node['data']['type'] = type_
+    return node
+
+project_node = _build_node('nodes')
+registration_node = _build_node('registrations')
+fake_node = _build_node('fakes')
 
 
 # Use this to fake a response when asking for a project's files/storages


### PR DESCRIPTION
Utilizes a redirect in APIv2 to avoid osf-cli needing to know whether a GUID refers to a `node` or a `registration` object.

Manually tested to verify this:
1) works
2) does not break file uploads.

Introduces a small side effect: provide a file GUID, and it breaks. It would have broken before, this just makes it break in a different place.