### PR TITLE
[MRG] Fixes bug preventing updates on large files

### DIFF
--- a/osfclient/models/storage.py
+++ b/osfclient/models/storage.py
@@ -75,7 +75,7 @@ class Storage(OSFCore, ContainerMixin):
                 parent = parent.create_folder(directory, exist_ok=True)
 
         url = parent._new_file_url
-        # peek at the file to check if it is an ampty file which needs special
+        # peek at the file to check if it is an empty file which needs special
         # handling in requests. If we pass a file like object to data that
         # turns out to be of length zero then no file is created on the OSF
         conn_error = False

--- a/osfclient/models/storage.py
+++ b/osfclient/models/storage.py
@@ -78,7 +78,7 @@ class Storage(OSFCore, ContainerMixin):
 
         # When uploading a large file (>a few MB) that already exists
         # we sometimes get a ConnectionError instead of a status == 409.
-        conn_error = False
+        connection_error = False
         
         # peek at the file to check if it is an empty file which needs special
         # handling in requests. If we pass a file like object to data that
@@ -90,9 +90,9 @@ class Storage(OSFCore, ContainerMixin):
             try:
                 response = self._put(url, params={'name': fname}, data=fp)
             except ConnectionError:
-                conn_error = True
+                connection_error = True
                 
-        if conn_error or response.status_code == 409:
+        if connection_error or response.status_code == 409:
             if not update:
                 # note in case of connection error, we are making an inference here
                 raise FileExistsError(path)

--- a/osfclient/models/storage.py
+++ b/osfclient/models/storage.py
@@ -1,12 +1,13 @@
 import os
 import six
 
+from requests.exceptions import ConnectionError
+
 from .core import OSFCore
 from .file import ContainerMixin
 from .file import File
 from ..utils import norm_remote_path
 from ..utils import file_empty
-
 
 if six.PY2:
     class FileExistsError(OSError):
@@ -76,13 +77,18 @@ class Storage(OSFCore, ContainerMixin):
         # peek at the file to check if it is an ampty file which needs special
         # handling in requests. If we pass a file like object to data that
         # turns out to be of length zero then no file is created on the OSF
+        conn_error = False
         if file_empty(fp):
             response = self._put(url, params={'name': fname}, data=b'')
         else:
-            response = self._put(url, params={'name': fname}, data=fp)
-
-        if response.status_code == 409:
+            try:
+                response = self._put(url, params={'name': fname}, data=fp)
+            except ConnectionError as err:
+                conn_error = True
+                
+        if conn_error or response.status_code == 409:
             if not update:
+                # note in case of connection error, we are making an inference here
                 raise FileExistsError(path)
 
             else:

--- a/osfclient/models/storage.py
+++ b/osfclient/models/storage.py
@@ -9,6 +9,7 @@ from .file import File
 from ..utils import norm_remote_path
 from ..utils import file_empty
 
+
 if six.PY2:
     class FileExistsError(OSError):
         """


### PR DESCRIPTION
If server breaks connection, proceed with update if user specifies --force option.
Fixes #133

Note: if the server breaks the connection we infer that this is due to the combination of a large file and resource already being present. This is not actually guaranteed, so raising `FileExistsError` could potentially result in misdirecting users. Perhaps additional reporting required?

