### PR TITLE
[MRG] EHN: provide the file hashes publicly

### DIFF
--- a/osfclient/models/file.py
+++ b/osfclient/models/file.py
@@ -37,6 +37,8 @@ class File(OSFCore):
                                                 'attributes', 'date_created')
         self.date_modified = self._get_attribute(file,
                                                  'attributes', 'date_modified')
+        self.hashes = self._get_attribute(file,
+                                          'attributes', 'extra', 'hashes')
 
     def __str__(self):
         return '<File [{0}, {1}]>'.format(self.id, self.path)


### PR DESCRIPTION
Getting the hashes for each file from the metadata would be really useful (e.g. check for file corruption or avoiding redownloading)

Apparently there is no tests checking the attributes associated with the file so I did not added a test.

@betatim Let me know it the change would make sense?