### PR TITLE
changed deploy repo from dib-lab/osf-cli to osfclient/osfclient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ deploy:
     distributions: sdist bdist_wheel
     on:
       tags: true
-      repo: dib-lab/osf-cli
+      repo: osfclient/osfclient
       condition: "$PYTHON_VERSION = 3.5"
     password:
       secure: IdQhl1tj2+qwDw0PpwlXfWdbvdK3blZbftWzjaXClSO9lDFiRMno/EX2u/Z6KVM4LTO87SrmBeah7SQWc5KMoSWjJ7nksQllmmMuFguS6PueWlkIjL0m2Aeu55+MPKmQQjcfjHYF7eFurPkvq7CS1mwdZSuVssBlvZP6O6TiHoE6KKAemPsgKFlbTNMFKj2/jo6Hnmw7l8RvSKTE4y47EOrhDmAk3HJmRIrZATposfqKr5k6g1WXkQhqFUPl+lHMRzue/mq9Eaf3Wtqe9lvZkWiv/FGay/VeUCIU1JDxh8o7Co4v45CSgEudKvo40osdwS+Sy7FtuydFM/uO9zTgrRh3ZkxfzeZSxfwHtqpEhGmaEOlEMRmbWIJSvmAhyx2nQSXehUzxee0mjWsbXdCCBE/8o7iBwmvIaISxnzME4EBHJJVqgnPMvylJbC9YzdGsS3tG2UBBO4ssyHcBiuFUzR5a5YkCdXol6Usi40tI044oAdndptpgRET71z1xJoTy+43S2gMiXIb3OW0XOH4I5/0iYgNT+2XtjrbUwbkK+gqmOK/vNOOM+6JG1kVm6D2SqocYN/zFhJvfeNCojrAF2QO7lja+WvjPR+I62psruegO9Sw8g2hw29wV4xKR5NRPez5exmxLvqF7/NLUZ5IGXoYG46mQ6xm0aO0DnTLBEn0=


### PR DESCRIPTION
I don't know if there's a reason to leave `dib-lab/osf-cli` as the deploy repo in `.travis.yml` instead of `osfclient/osfclient`, but the travis error [here](https://travis-ci.org/osfclient/osfclient/jobs/409185936#L865) makes it seem like the change is necessary, and making the change seemed to fix the problem [here](https://travis-ci.org/benlindsay/osfclient/builds/409188104)