### PR TITLE
[MRG] Update test PyPI URL used by Travis deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,12 @@ deploy:
 
   # test pypi
   - provider: pypi
+    # We upload to the PyPI *test* site on every PR merge to get some early
+    # warning if our deploy steps stop working.
     # this line together with `setup.cfg` creates universal wheels as long as
     # osfclient is a python only module (no compiled code)
     distributions: sdist bdist_wheel
-    server: https://testpypi.python.org/pypi
+    server: https://test.pypi.org/legacy/
     user: "jackrabbit"
     password:
       secure: U6hl13NL7WtH49npp3tmw3dLEKHrw3PZamTJ6oa1N79PPLugA38ZMG0Alu4JGQgyMFRad+XlVlxD0uq6Y6P3xktfUIw5fcKDCvrCjfOZnR3fT8wnbtxsyjXWfnhXCqTL9nzZ5AJrEHFD+g1lsTzTPko2fSU3k/n5un26dxnvhotLATBtwAnlc4vLVGQ5kTaiUi5m30E3hESudODMbipXm2S7FZ8RjvvnvjNJ5TxZVK6EQHlqdY+VAv22bf765Ti5TTatvIoaee6gbojDCXM28ve4G8h7RB1SiJWSaxfQqcVC3iJGe03nT1YwYbsVYUAsJmVwj0Pf08PwXC7g/1lh0cjnf2WXD9XbqPmFmpmot7Jr3iWzZhKBaBmmlQC57nOXIzf0EE+7ULZAjkH+Fu9vAIuzF8/CjCEdQHobPt5h3V4ZwhcTvoCE5I3yxgbs9dSiRAYzWQywRfVt7jxhOMN+cchdPELA4oxWRD9u0u+mPvJwnKx0ui1/Ki8AWM6Hq6LZCdkTZktVrvE5+ovjegxLMTWEvrzv+wrUpzYIuQ05wjBTCuZCSwBRxAk+0ck58B430EgCTSdD9w0PYc4T+0sli9H85vb4zZQkdv00K1bJZMhAao4orAKthCENBiFP8H0g7IdztSmXd7lVwpAHcqtpOEBRhcayD4KqlPO1TCcOxUE=


### PR DESCRIPTION
Follow up #153 

The idea behind uploading to test PyPI on every merged PR is that we get to exercise the deploy step. Instead of only finding out when we make a release that the deploy setup is broken.

I am not sure it is a good idea to keep doing this and if we keep having trouble I would vote to remove this instead of trying to fix it (I think) :-/