### PR TITLE
[WIP] added info about secrets to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,4 +112,14 @@ To setup a development version:
     $ pip install -r devRequirements.txt
     $ pip install -e.
 
+The following secrets are used for this project:
+
+- test.pypi.org password
+
+If you need access to any of these secrets to contribute to this project,
+contact one of the following maintaners on `Keybase <//keybase.io>`__:
+
+- Tim Head (@betatim)
+- Ben Lindsay (@benlindsay)
+
 For more details and instructions: `CONTRIBUTING.md <CONTRIBUTING.md>`__


### PR DESCRIPTION
@betatim Is this kind of what you meant in #157 by the following?

>We can add a sentence to the README stating what secrets there are, who they've been shared with and what to do if one wants to get a copy.

I'm not sure what other secrets there are that might be necessary to share, or if you had in mind more robust ideas for managing project secrets, or if I'm missing people who should be on the list. Let me know if this is all way off.