### PR TITLE
[WIP] Added option to login with Personal Access Token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ __pycache__/
 .coverage
 coverage.xml
 .osfcli.config
+.idea
 
+#tests
+.pytest_cache/
 # docs build output
 docs/_build
+
+#venv
+venv/

--- a/osfclient/api.py
+++ b/osfclient/api.py
@@ -12,12 +12,19 @@ class OSF(OSFCore):
     """
     def __init__(self, username=None, password=None, token=None):
         super(OSF, self).__init__({})
-        if username is not None and password is not None:
-            self.login(username, password)
+        try:
+            self.login(username, password, token)
+        except OSFException:
+            pass
 
-    def login(self, username, password=None, token=None):
+    def login(self, username=None, password=None, token=None):
         """Login user for protected API calls."""
-        self.session.basic_auth(username, password)
+        if token is not None:
+            self.session.token_auth(token)
+        elif username is not None and password is not None:
+            self.session.basic_auth(username, password)
+        else:
+            raise OSFException("No login details provided.")
 
     def project(self, project_id):
         """Fetch project `project_id`."""

--- a/osfclient/models/session.py
+++ b/osfclient/models/session.py
@@ -27,6 +27,9 @@ class OSFSession(requests.Session):
         if 'Authorization' in self.headers:
             self.headers.pop('Authorization')
 
+    def token_auth(self, token):
+        self.headers['Authorization'] = "Bearer %s" % token
+
     def build_url(self, *args):
         parts = [self.base_url]
         parts.extend(args)

--- a/osfclient/tests/test_api.py
+++ b/osfclient/tests/test_api.py
@@ -17,13 +17,28 @@ def test_basic_auth(session_basic_auth):
     session_basic_auth.assert_called_with('joe@example.com', 'secret_password')
 
 
+@patch.object(OSFSession, 'token_auth')
+def test_token_auth(session_token_auth):
+    OSF(token='asdfg')
+    session_token_auth.assert_called_with('asdfg')
+
+
 @patch.object(OSFSession, 'basic_auth')
-def test_login(session_basic_auth):
+def test_login_username_password(session_basic_auth):
     osf = OSF()
     assert not session_basic_auth.called
 
     osf.login('joe@example.com', 'secret_password')
     session_basic_auth.assert_called_with('joe@example.com', 'secret_password')
+
+
+@patch.object(OSFSession, 'token_auth')
+def test_login_token(session_token_auth):
+    osf = OSF()
+    assert not session_token_auth.called
+
+    osf.login(token="asdfg")
+    session_token_auth.assert_called_with("asdfg")
 
 
 @patch.object(OSFCore, '_get', return_value=FakeResponse(200, project_node))

--- a/osfclient/tests/test_session.py
+++ b/osfclient/tests/test_session.py
@@ -14,6 +14,12 @@ def test_basic_auth():
     assert 'Authorization' not in session.headers
 
 
+def test_token_auth():
+    session = OSFSession()
+    session.token_auth('asdfg')
+    assert 'Authorization' in session.headers
+
+
 def test_basic_build_url():
     session = OSFSession()
     url = session.build_url("some", "path")


### PR DESCRIPTION
Adresses #101 and #99.

Basically, I just added a new login function to the Session class which sets the correct header. API constructor and login functions are changed to transparently use token-based login procedure if a token is provided.

This is my first public contribution, so I marked it as WIP, although I am not sure what else to to. It would be great if you could review and advise accordingly. Thank you!