### PR TITLE
enable and document basic list call from python library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ out the command-line program.
 
 Read the full documentation: http://osfclient.readthedocs.io/en/latest/
 
-Below are some examples on how to use it:
+Below are some CLI examples on how to use it:
 
 ::
 
@@ -92,6 +92,18 @@ username and project ID create ``.osfcli.config``:
 
 after which you can simply run ``osf ls`` to list the contents of the
 project.
+
+
+Although not fully supported, in order to use the library directly from within Python, you can call it like this:
+
+::
+
+    import osfclient
+    import osfclient.cli
+    osf_login = osfclient.OSF(username=[username], password=[password])
+    osf_login.project=[project]
+    osfclient.cli.list_(osf_login)
+
 
 Contributing
 ============

--- a/osfclient/cli.py
+++ b/osfclient/cli.py
@@ -70,7 +70,10 @@ def _setup_osf(args):
 
     password = None
     if username is not None:
-        password = os.getenv("OSF_PASSWORD")
+        if args.password is None:
+            password = os.getenv("OSF_PASSWORD")
+        else:
+            password = args.password
 
         # Prompt user when password is not set
         if password is None:


### PR DESCRIPTION
Hi,

We wanted to use this from within a Python script and found that those methods weren't really documented or designed that way, so I've added a basic method and example for doing that.