### PR TITLE
Fix file access URL for downloads

### DIFF
--- a/osfclient/models/file.py
+++ b/osfclient/models/file.py
@@ -26,8 +26,8 @@ class File(OSFCore):
         self.id = self._get_attribute(file, 'id')
 
         self._endpoint = self._get_attribute(file, 'links', 'self')
-        self._download_url = self._get_attribute(file, 'links', 'download')
         self._upload_url = self._get_attribute(file, 'links', 'upload')
+        self._download_url = self._upload_url
         self._delete_url = self._get_attribute(file, 'links', 'delete')
         self.osf_path = self._get_attribute(file, 'attributes', 'path')
         self.path = self._get_attribute(file,


### PR DESCRIPTION
Was trying to use URLs like `https://osf.io/download/4rfew/`

Now this style:
`https://files.osf.io/v1/resources/fwefw/providers/osfstorage/5ee88fsdfafe0040c4a3b3`

Which happens to be the same as the upload URL.

Fixes #172
Fixes #144