### PR TITLE
New Feature: implement http patch method in OSF session

### DIFF
--- a/osfclient/models/core.py
+++ b/osfclient/models/core.py
@@ -28,6 +28,9 @@ class OSFCore(object):
     def _delete(self, url, *args, **kwargs):
         return self.session.delete(url, *args, **kwargs)
 
+    def _patch(self, url, *args, **kwargs):
+        return self.session.patch(url, *args, **kwargs)
+
     def _get_attribute(self, json, *keys, **kwargs):
         # pick value out of a (nested) dictionary/JSON
         # `keys` is a list of keys

--- a/osfclient/models/session.py
+++ b/osfclient/models/session.py
@@ -74,3 +74,9 @@ class OSFSession(requests.Session):
         if response.status_code == 401:
             raise UnauthorizedException()
         return response
+
+    def patch(self, url, *args, **kwargs):
+        response = super(OSFSession, self).patch(url, *args, **kwargs)
+        if response.status_code == 401:
+            raise UnauthorizedException()
+        return response


### PR DESCRIPTION
I have searched for a way to update an existing OSF project (e.g., description, tags, category, ...) from within a script and couldn't find a way with the existing source code (I may have missed it, so please let me know if there is another, already implemented way to do this). This PR adds support for patching a resource, and thus lays the ground work for updating nodes via PATCH request.
