### PR TITLE
[CR] Support token auth for write commands

### DIFF
--- a/osfclient/api.py
+++ b/osfclient/api.py
@@ -12,8 +12,10 @@ class OSF(OSFCore):
     """
     def __init__(self, username=None, password=None, token=None):
         super(OSF, self).__init__({})
+        self.can_login = False
         try:
             self.login(username, password, token)
+            self.can_login = True
         except OSFException:
             pass
 
@@ -47,3 +49,8 @@ class OSF(OSFCore):
     def password(self):
         if self.session.auth is not None:
             return self.session.auth[1]
+
+    @property
+    def token(self):
+        if self.session.token is not None:
+            return self.session.token

--- a/osfclient/cli.py
+++ b/osfclient/cli.py
@@ -293,9 +293,9 @@ def upload(args):
     $ osf upload -r foo/ bar
     """
     osf = _setup_osf(args)
-    if osf.username is None or osf.password is None:
-        sys.exit('To upload a file you need to provide a username and'
-                 ' password.')
+    if not osf.can_login:
+        sys.exit('To upload a file you need to provide either a username and'
+                 ' password or a token.')
 
     project = osf.project(args.project)
     storage, remote_path = split_storage(args.destination)
@@ -335,9 +335,9 @@ def remove(args):
     used.
     """
     osf = _setup_osf(args)
-    if osf.username is None or osf.password is None:
-        sys.exit('To remove a file you need to provide a username and'
-                 ' password.')
+    if not osf.can_login:
+        sys.exit('To remove a file you need to provide either a username and'
+                 ' password or a token.')
 
     project = osf.project(args.project)
 

--- a/osfclient/models/session.py
+++ b/osfclient/models/session.py
@@ -46,6 +46,7 @@ class OSFSession(requests.Session):
             })
         self.base_url = 'https://api.osf.io/v2/'
         self.last_request = None
+        self.token = None
 
     def basic_auth(self, username, password):
         self.auth = (username, password)
@@ -53,6 +54,7 @@ class OSFSession(requests.Session):
             self.headers.pop('Authorization')
 
     def token_auth(self, token):
+        self.token = token
         self.headers['Authorization'] = "Bearer %s" % token
 
     def build_url(self, *args):

--- a/osfclient/tests/test_removing.py
+++ b/osfclient/tests/test_removing.py
@@ -18,7 +18,7 @@ def test_anonymous_doesnt_work():
     with pytest.raises(SystemExit) as e:
         remove(args)
 
-    expected = 'remove a file you need to provide a username and password'
+    expected = 'To remove a file you need to provide either a username and password or a token.'
     assert expected in e.value.args[0]
 
 

--- a/osfclient/tests/test_uploading.py
+++ b/osfclient/tests/test_uploading.py
@@ -20,7 +20,7 @@ def test_anonymous_doesnt_work():
     with pytest.raises(SystemExit) as e:
         upload(args)
 
-    expected = 'upload a file you need to provide a username and password'
+    expected = 'To upload a file you need to provide either a username and password or a token.'
     assert expected in e.value.args[0]
 
 


### PR DESCRIPTION
 * Personal access token support was added in #181, but our write
   methods (upload & remove) were using obsolete logic to validate
   write support.  Update `session` object to track whether auth was
   successful rather than what parameters were passed.

 * Update validation failure messages for upload/remove along with
   relevant tests.

 * Allow the `OSF` object to track the given token.  This is not
   currently needed, but is provided to maintain symmetry with the
   current username & password behavior.