### PR TITLE
Exceptions for unexpected response status codes

### DIFF
--- a/osfclient/exceptions.py
+++ b/osfclient/exceptions.py
@@ -12,44 +12,46 @@ class FolderExistsException(OSFException):
 
 
 class ToManyRequests(OSFException):
-    def __init__(self, msg='Too many requests have been sent. See '
-                           'https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps'
-                           'for details', *args, **kwargs):
+    def __init__(self, msg, *args, **kwargs):
+        msg = msg + 'Too many requests have been sent. See '
+        'https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps'
+        'for details'
         super().__init__(msg, *args, **kwargs)
 
 
 class NotFound(OSFException):
-    def __init__(self, msg='The requested resource does not exist.', *args, **kwargs):
+    def __init__(self, msg, *args, **kwargs):
+        msg = msg + ' The requested resource does not exist.'
         super().__init__(msg, *args, **kwargs)
 
 
 class Gone(OSFException):
-    def __init__(self, msg='The requested resource is no longer available,'
-                           ' most likely because it was deleted.', *args, **kwargs):
+    def __init__(self, msg, *args, **kwargs):
+        msg = msg + ' The requested resource is no longer available,'
+        ' most likely because it was deleted.'
         super().__init__(msg, *args, **kwargs)
 
 
 class ServerError(OSFException):
-    def __init__(self, msg='The API server encountered an unexpected error.', *args, **kwargs):
+    def __init__(self, msg, *args, **kwargs):
+        msg = msg + ' The API server encountered an unexpected error.'
         super().__init__(msg, *args, **kwargs)
 
 
 class BadRequest(OSFException):
-    def __init__(self, msg='The request was unacceptable, often due to a'
-                           ' missing required parameter or malformed data.', *args, **kwargs):
+    def __init__(self, msg, *args, **kwargs):
+        msg = msg + 'The request was unacceptable, often due to a'
+        ' missing required parameter or malformed data.'
         super().__init__(msg, *args, **kwargs)
 
 
 def raise_unexp_status(status_code, expected_code=200, msg=None):
-    exc, msg = {
-        400: (BadRequest, msg),
-        401: (UnauthorizedException, msg),
-        404: (NotFound, msg),
-        410: (Gone, msg),
-        429: (ToManyRequests, msg),
-    }.get(status_code, (OSFException, "Response has status "
-                                      "code {} not {}".format(status_code, expected_code)))
-    if msg is not None:
-        raise exc(msg=msg)
-    else:
-        raise exc
+    msg = msg or "Response has status code {} not {}".format(status_code, expected_code)
+    exc= {
+        400: BadRequest,
+        401: UnauthorizedException,
+        404: NotFound,
+        410: Gone,
+        429: ToManyRequests,
+    }.get(status_code, OSFException)
+    raise exc(msg=msg)

--- a/osfclient/exceptions.py
+++ b/osfclient/exceptions.py
@@ -1,9 +1,13 @@
 class OSFException(Exception):
-    pass
+    def __init__(self, msg=None, *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)
 
 
 class UnauthorizedException(OSFException):
-    pass
+    def __init__(self, msg=None, *args, **kwargs):
+        msg = ('' if msg is None else msg + 'The request requires user'
+               ' authentication, which was not provided.')
+        super().__init__(msg, *args, **kwargs)
 
 
 class FolderExistsException(OSFException):
@@ -13,45 +17,47 @@ class FolderExistsException(OSFException):
 
 class ToManyRequests(OSFException):
     def __init__(self, msg, *args, **kwargs):
-        msg = msg + 'Too many requests have been sent. See '
-        'https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps'
-        'for details'
+        msg = msg + 'Too many requests have been sent. See' \
+                    ' https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps' \
+                    ' for details.'
         super().__init__(msg, *args, **kwargs)
 
 
 class NotFound(OSFException):
     def __init__(self, msg, *args, **kwargs):
-        msg = msg + ' The requested resource does not exist.'
+        msg = msg + 'The requested resource does not exist.'
         super().__init__(msg, *args, **kwargs)
 
 
 class Gone(OSFException):
     def __init__(self, msg, *args, **kwargs):
-        msg = msg + ' The requested resource is no longer available,'
-        ' most likely because it was deleted.'
+        msg = msg + 'The requested resource is no longer available,' \
+                    ' most likely because it was deleted.'
         super().__init__(msg, *args, **kwargs)
 
 
 class ServerError(OSFException):
     def __init__(self, msg, *args, **kwargs):
-        msg = msg + ' The API server encountered an unexpected error.'
+        msg = msg + 'The API server encountered an unexpected error.'
         super().__init__(msg, *args, **kwargs)
 
 
 class BadRequest(OSFException):
     def __init__(self, msg, *args, **kwargs):
-        msg = msg + 'The request was unacceptable, often due to a'
-        ' missing required parameter or malformed data.'
+        msg = msg + 'The request was unacceptable, often due to a ' \
+                    'missing required parameter or malformed data.'
         super().__init__(msg, *args, **kwargs)
 
 
 def raise_unexp_status(status_code, expected_code=200, msg=None):
-    msg = msg or "Response has status code {} not {}".format(status_code, expected_code)
-    exc= {
+    msg = msg or "Response has status code {} not {}.".format(status_code, expected_code)
+    status_code = 500 if 500 <= status_code < 600 else status_code
+    exc = {
         400: BadRequest,
         401: UnauthorizedException,
         404: NotFound,
         410: Gone,
         429: ToManyRequests,
+        500: ServerError
     }.get(status_code, OSFException)
     raise exc(msg=msg)

--- a/osfclient/exceptions.py
+++ b/osfclient/exceptions.py
@@ -9,3 +9,47 @@ class UnauthorizedException(OSFException):
 class FolderExistsException(OSFException):
     def __init__(self, name):
         self.args = ('Folder %s already exists.' % name,)
+
+
+class ToManyRequests(OSFException):
+    def __init__(self, msg='Too many requests have been sent. See '
+                           'https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps'
+                           'for details', *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)
+
+
+class NotFound(OSFException):
+    def __init__(self, msg='The requested resource does not exist.', *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)
+
+
+class Gone(OSFException):
+    def __init__(self, msg='The requested resource is no longer available,'
+                           ' most likely because it was deleted.', *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)
+
+
+class ServerError(OSFException):
+    def __init__(self, msg='The API server encountered an unexpected error.', *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)
+
+
+class BadRequest(OSFException):
+    def __init__(self, msg='The request was unacceptable, often due to a'
+                           ' missing required parameter or malformed data.', *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)
+
+
+def raise_unexp_status(status_code, expected_code=200, msg=None):
+    exc, msg = {
+        400: (BadRequest, msg),
+        401: (UnauthorizedException, msg),
+        404: (NotFound, msg),
+        410: (Gone, msg),
+        429: (ToManyRequests, msg),
+    }.get(status_code, (OSFException, "Response has status "
+                                      "code {} not {}".format(status_code, expected_code)))
+    if msg is not None:
+        raise exc(msg=msg)
+    else:
+        raise exc

--- a/osfclient/models/core.py
+++ b/osfclient/models/core.py
@@ -1,6 +1,7 @@
 import numbers
 
 from .session import OSFSession
+from ..exceptions import raise_unexp_status
 
 
 # Base class for all models and the user facing API object
@@ -58,9 +59,7 @@ class OSFCore(object):
         if response.status_code in status_code:
             return response.json()
         else:
-            raise RuntimeError("Response has status "
-                               "code {} not {}".format(response.status_code,
-                                                       status_code))
+            raise_unexp_status(response.status_code, status_code)
 
     def _follow_next(self, url):
         """Follow the 'next' link on paginated results."""

--- a/osfclient/models/core.py
+++ b/osfclient/models/core.py
@@ -59,7 +59,7 @@ class OSFCore(object):
         if response.status_code in status_code:
             return response.json()
         else:
-            raise_unexp_status(response.status_code, status_code)
+            raise_unexp_status(response.status_code, expected_code=status_code)
 
     def _follow_next(self, url):
         """Follow the 'next' link on paginated results."""

--- a/osfclient/models/file.py
+++ b/osfclient/models/file.py
@@ -61,14 +61,13 @@ class File(OSFCore):
                         int(response.headers['Content-Length']))
 
         else:
-            raise RuntimeError("Response has status "
-                               "code {}.".format(response.status_code))
+            raise raise_unexp_status(response.status_code)
 
     def remove(self):
         """Remove this file from the remote storage."""
         response = self._delete(self._delete_url)
         if response.status_code != 204:
-            raise RuntimeError('Could not delete {}.'.format(self.path))
+            raise raise_unexp_status(response.status_code, msg='Could not delete {}.'.format(self.path))
 
     def update(self, fp):
         """Update the remote file from a local file.
@@ -91,7 +90,7 @@ class File(OSFCore):
         if response.status_code != 200:
             msg = ('Could not update {} (status '
                    'code: {}).'.format(self.path, response.status_code))
-            raise RuntimeError(msg)
+            raise_unexp_status(response.status_code, msg=msg)
 
 
 class ContainerMixin:
@@ -144,7 +143,7 @@ class ContainerMixin:
             return _WaterButlerFolder(response.json()['data'], self.session)
 
         else:
-            raise RuntimeError("Response has status code {} while creating "
+            raise_unexp_status(response.status_code, msg="Response has status code {} while creating "
                                "folder {}.".format(response.status_code,
                                                    name))
 

--- a/osfclient/models/file.py
+++ b/osfclient/models/file.py
@@ -1,7 +1,7 @@
 from tqdm import tqdm
 
 from .core import OSFCore
-from ..exceptions import FolderExistsException
+from ..exceptions import FolderExistsException, raise_unexp_status
 
 
 def copyfileobj(fsrc, fdst, total, length=16*1024):

--- a/osfclient/tests/test_api.py
+++ b/osfclient/tests/test_api.py
@@ -2,7 +2,7 @@ from mock import call, patch
 import pytest
 
 from osfclient import OSF
-from osfclient.exceptions import OSFException
+from osfclient.exceptions import OSFException, NotFound
 from osfclient.models import OSFSession
 from osfclient.models import OSFCore
 from osfclient.models import Project
@@ -76,7 +76,7 @@ def test_get_fake(OSFCore_get):
 @patch.object(OSFCore, '_get', return_value=FakeResponse(404, project_node))
 def test_failed_get_project(OSFCore_get):
     osf = OSF()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(NotFound):
         osf.project('f3szh')
 
     OSFCore_get.assert_called_once_with(

--- a/osfclient/tests/test_exceptions.py
+++ b/osfclient/tests/test_exceptions.py
@@ -1,0 +1,88 @@
+import pytest
+
+import osfclient.exceptions as exc
+
+
+def test_400():
+    with pytest.raises(exc.BadRequest) as e:
+        exc.raise_unexp_status(400, msg="Test.")
+    assert str(e.value) == 'Test.The request was unacceptable, often due' \
+                           ' to a missing required parameter or malformed data.'
+
+    with pytest.raises(exc.BadRequest) as e:
+        exc.raise_unexp_status(400, expected_code=1)
+    assert str(e.value) == 'Response has status code 400 not 1.The request' \
+                           ' was unacceptable, often due to a missing' \
+                           ' required parameter or malformed data.'
+
+
+def test_401():
+    with pytest.raises(exc.UnauthorizedException) as e:
+        exc.raise_unexp_status(401, msg="Test.")
+    assert str(e.value) == 'Test.The request requires user authentication, which was not provided.'
+
+    with pytest.raises(exc.UnauthorizedException) as e:
+        exc.raise_unexp_status(401, expected_code=1)
+    assert str(e.value) == 'Response has status code 401 not 1.The request ' \
+                           'requires user authentication, which was not provided.'
+
+
+def test_404():
+    with pytest.raises(exc.NotFound) as e:
+        exc.raise_unexp_status(404, msg="Test.")
+    assert str(e.value) == 'Test.The requested resource does not exist.'
+
+    with pytest.raises(exc.NotFound) as e:
+        exc.raise_unexp_status(404, expected_code=1)
+    assert str(e.value) == 'Response has status code 404 not 1.The' \
+                           ' requested resource does not exist.'
+
+
+def test_410():
+    with pytest.raises(exc.Gone) as e:
+        exc.raise_unexp_status(410, msg="Test.")
+    assert str(e.value) == 'Test.The requested resource is no longer' \
+                           ' available, most likely because it was deleted.'
+
+    with pytest.raises(exc.Gone) as e:
+        exc.raise_unexp_status(410, expected_code=1)
+    assert str(e.value) == 'Response has status code 410 not 1.The requested' \
+                           ' resource is no longer available, most likely because it was deleted.'
+
+
+def test_429():
+    with pytest.raises(exc.ToManyRequests) as e:
+        exc.raise_unexp_status(429, msg="Test.")
+    assert str(e.value) == 'Test.Too many requests have been sent. See' \
+                    ' https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps' \
+                    ' for details.'
+
+    with pytest.raises(exc.ToManyRequests) as e:
+        exc.raise_unexp_status(429, expected_code=1)
+    assert str(e.value) == 'Response has status code 429 not 1.Too many requests have been sent. See' \
+                           ' https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps' \
+                           ' for details.'
+
+
+def test_5xx():
+    with pytest.raises(exc.ServerError) as e:
+        exc.raise_unexp_status(500, msg="Test.")
+    assert str(e.value) == 'Test.The API server encountered an unexpected error.'
+
+    with pytest.raises(exc.ServerError) as e:
+        exc.raise_unexp_status(503, expected_code=1)
+    assert str(e.value) == 'Response has status code 503 not 1.The API server encountered an unexpected error.'
+
+
+def test_other_code():
+    with pytest.raises(exc.OSFException) as e:
+        exc.raise_unexp_status(300, msg='Test.')
+    assert str(e.value) == 'Test.'
+
+    with pytest.raises(exc.OSFException) as e:
+        exc.raise_unexp_status(303)
+    assert str(e.value) == 'Response has status code 303 not 200.'
+
+    with pytest.raises(exc.OSFException) as e:
+        exc.raise_unexp_status(303, expected_code=204)
+    assert str(e.value) == 'Response has status code 303 not 204.'

--- a/osfclient/tests/test_file.py
+++ b/osfclient/tests/test_file.py
@@ -9,7 +9,7 @@ import pytest
 from osfclient.models import OSFCore
 from osfclient.models import File
 from osfclient.models import Folder
-from osfclient.exceptions import FolderExistsException
+from osfclient.exceptions import FolderExistsException, NotFound
 from osfclient.models.file import _WaterButlerFolder
 
 from osfclient.tests import fake_responses
@@ -184,7 +184,7 @@ def test_remove_file_failed():
     f._delete_url = 'http://delete.me/uri'
     f._delete = MagicMock(return_value=FakeResponse(404, {'data': {}}))
 
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(NotFound) as e:
         f.remove()
 
     assert f._delete.called


### PR DESCRIPTION
This PR adds special exceptions to the unexpected response status code. This is more useful than raising ```Runtime Error``` because it provides more information about the reason of an exception - many different reasons can cause ```Runtime Error```. Tests also added.

close #186