### PR TITLE
Pwd from config

### DIFF
--- a/osfclient/cli.py
+++ b/osfclient/cli.py
@@ -76,9 +76,11 @@ def _setup_osf(args):
 
     token = config.get('token', None)
 
-    password = None
-    if username is not None and token is None:
-        password = os.getenv("OSF_PASSWORD")
+    password = config.get('password', None)
+    if username is not None and token is None and password is None:
+        # only overwrite password from config file if $OSF_PASSWORD is set
+        if os.getenv("OSF_PASSWORD") is not None:
+            password = os.getenv("OSF_PASSWORD")
 
         # Prompt user when password is not set
         if password is None:

--- a/osfclient/cli.py
+++ b/osfclient/cli.py
@@ -78,9 +78,7 @@ def _setup_osf(args):
 
     password = config.get('password', None)
     if username is not None and token is None and password is None:
-        # only overwrite password from config file if $OSF_PASSWORD is set
-        if os.getenv("OSF_PASSWORD") is not None:
-            password = os.getenv("OSF_PASSWORD")
+        password = os.getenv("OSF_PASSWORD")
 
         # Prompt user when password is not set
         if password is None:


### PR DESCRIPTION
A `password` that was set in `.osfcli.config` was not used so far, in contrary to what is said in the `README`. With this PR it is.

commandline > environment > config file is preserved.

