### PR TITLE
Add ability to list / clone wiki pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,12 @@ Below are some examples on how to use it:
     # add a new directory
     $ osf upload -r local/directory/ remote/directory
 
+    # list all wiki pages for an existing project(/component)
+    osf -p <project id> -u <username> list_wikis
+
+    # clone all wiki pages for an existing project(/component)
+    osf -p <project id> -u <username> clone_wikis <output directory>
+
 If the project is private you will need to provide authentication
 details.  You can provide either username & password credentials or a
 Personal Access Token (PAT).  You can provide these by setting either

--- a/osfclient/__main__.py
+++ b/osfclient/__main__.py
@@ -4,7 +4,7 @@ import six
 import argparse
 from textwrap import dedent
 
-from .cli import clone, fetch, geturl, list_, remove, upload, init
+from .cli import clone, fetch, geturl, list_, remove, upload, init, list_wikis, clone_wikis
 from . import __version__
 
 
@@ -85,6 +85,16 @@ def main():
     # List all files in a project
     list_parser = _add_subparser('list', list.__doc__, aliases=['ls'])
     list_parser.set_defaults(func=list_)
+
+    # List all wikis in a project(/component)
+    wiki_list_parser = _add_subparser('list_wikis', list_wikis.__doc__,)
+    wiki_list_parser.set_defaults(func=list_wikis)
+
+    # Clone all wikis in a project(/component)
+    wiki_clone_parser = _add_subparser('clone_wikis', clone_wikis.__doc__,)
+    wiki_clone_parser.set_defaults(func=clone_wikis)
+    wiki_clone_parser.add_argument('output', help='Write files to this directory',
+                              default=None, nargs='?')
 
     # Upload a single file or a directory tree
     upload_parser = _add_subparser('upload', upload.__doc__)

--- a/osfclient/cli.py
+++ b/osfclient/cli.py
@@ -270,6 +270,49 @@ def list_(args):
 
             print(os.path.join(prefix, path))
 
+@might_need_auth
+def list_wikis(args):
+    """List all wiki pages for project.
+
+    If the project is private you need to specify a username.
+    """
+    osf = _setup_osf(args)
+
+    project = osf.project(args.project)
+    
+    print(list(project.wikis))
+
+@might_need_auth
+def clone_wikis(args):
+    """Download all wiki pages for project(/component).
+
+    The output directory defaults to the current directory.
+    A subdirectory of the output directory will be created, named
+    the project ID. Wiki pages will be saved as markdown files, named
+    <cleaned wiki page name>_<id>.md
+    
+    If the project is private you need to specify a username.
+    """
+    from django.utils.text import slugify
+    osf = _setup_osf(args)
+    project = osf.project(args.project)
+    
+    output_dir = args.project
+    if args.output is not None:
+        output_dir = args.output
+
+    wikis = project.wikis
+
+    prefix = os.path.join(output_dir, args.project, 'wiki')
+
+    headers = {'Accept': '*/*'}
+    os.makedirs(prefix, exist_ok=True)
+    print('%s wiki pages found' % len(wikis))
+    for wiki in wikis:
+        # filename will be <cleaned wiki page name>_<id>.md
+        path = os.path.join(prefix, slugify(wiki[1]) + '_%s.md' % wiki[0])
+        with open(path, "wb") as f:
+            f.write(project.session.get(wiki[-1], headers=headers).content)
 
 @might_need_auth
 def upload(args):

--- a/osfclient/models/project.py
+++ b/osfclient/models/project.py
@@ -24,6 +24,8 @@ class Project(OSFCore):
         storages = ['relationships', 'files', 'links', 'related', 'href']
         self._storages_url = self._get_attribute(project, *storages)
 
+        self._wikis_node_url = self.session.build_url('nodes/%s/wikis/' % self.id)
+
     def __str__(self):
         return '<Project [{0}]>'.format(self.id)
 
@@ -39,6 +41,40 @@ class Project(OSFCore):
         raise RuntimeError("Project has no storage "
                            "provider '{}'".format(provider))
 
+    @property
+    def wikis(self):
+        """Return wiki pages for this project/component
+
+        Returns
+        -------
+        list
+            List of tuples. One element per wiki page,
+            containing (ID, name, view_url, download_url)
+        """
+        wiks = self._json(self._get(self._wikis_node_url), 200)
+        wiki_data = wiks['data']
+
+        wiki_page_info = []
+
+        # print('Fetching %s wiki pages' % wiks['meta'])
+
+        next = wiks['links']['next']
+        print(next)
+
+        while next is not None:
+            wiks = self._json(self._get(next), 200)
+            wiki_data.extend(wiks['data'])
+            next = wiks['links']['next']
+
+        for wik in wiki_data:
+            wiki_id = wik['id']
+            name = wik['attributes']['name']
+            view = 'https://osf.io/' + self.id + '/wiki/' + name + '/'
+            download = wik['links']['download']
+            wiki_page_info.append((wiki_id, name, view, download))
+        
+        return wiki_page_info
+    
     @property
     def storages(self):
         """Iterate over all storages for this projects."""


### PR DESCRIPTION
Addresses #132 and #192, and is a workaround for an OSF.io issue trying to scroll through a alrge wiki (https://github.com/CenterForOpenScience/osf.io/issues/10295)

I haven't added a test, but could/should do. Ideally would use the OSF API v2 test server, though it doesn't have wiki pages at the moment. If someone starts to actively review pull requests again for this project, I'd be happy to do more on it